### PR TITLE
Aggregate sector categories into macro sectors

### DIFF
--- a/appSadipem.py
+++ b/appSadipem.py
@@ -181,29 +181,130 @@ elif page == 'Interno Vs Externo':
         df = df[df['sector'] == sector_sel]
     if st.session_state['ver_por_sector']:
         import plotly.express as px
+        macrosectores_dict = {
+            "Social": [
+                "Health", "Health education", "Health personnel development", "Health policy and administrative management",
+                "Basic health care", "Basic health infrastructure", "Medical services", "Medical education/training",
+                "Reproductive health care", "STD control including HIV/AIDS", "Malaria control", "Tuberculosis control",
+                "Basic nutrition", "Family planning",
+                "Education", "Education facilities and training", "Education policy and administrative management", "Early childhood education",
+                "Higher education", "Lower secondary education", "Upper Secondary Education (modified and includes data from 11322)",
+                "Teacher training", "Trade education/training", "Vocational training", "Educational research",
+                "Basic life skills for youth", "Recreation and sport",
+                "Social protection", "Social protection and welfare services policy, planning and administration",
+                "Social services (incl youth development and women+ children)", "Civil service pensions", "General pensions", "Low-cost housing", "Housing policy and administrative management"
+            ],
+            "Productivo": [
+                "Agriculture, forestry and fishing", "Agricultural development", "Agricultural co-operatives", "Agricultural extension",
+                "Agricultural education/training", "Agricultural inputs", "Agricultural land resources", "Agricultural alternative development",
+                "Agricultural policy and administrative management", "Agricultural financial services", "Agricultural research", "Agricultural services",
+                "Agricultural water resources", "Agro-industries", "Livestock", "Fishery development", "Fishery services", "Fishing policy and administrative management",
+                "Forestry development", "Forestry policy and administrative management",
+                "Industry, mining, construction", "Industrial development", "Industrial policy and administrative management", "Technological research and development",
+                "Business policy and administration", "Small and medium-sized enterprises (SME) development",
+                "Tourism policy and administrative management", "Responsible business conduct",
+                "Banking and financial services", "Formal sector financial intermediaries", "Informal/semi-formal financial intermediaries", "Monetary institutions",
+                "Financial policy and administrative management", "Retail gas distribution"
+            ],
+            "Infraestructura": [
+                "Transport and storage", "Transport policy, planning and administration", "Transport regulation", "Feeder road construction", "National road construction",
+                "Rail transport", "Water transport", "Air transport", "Public transport services",
+                "Water supply and sanitation", "Water supply and sanitation - large systems", "Basic drinking water supply", "Basic drinking water supply and basic sanitation",
+                "Basic sanitation", "Sanitation - large systems", "Waste management/disposal", "Water supply - large systems",
+                "Electric power transmission and distribution (centralised grids)", "Energy generation and supply", "Energy generation, renewable sources - multiple technologies",
+                "Energy sector policy, planning and administration", "Energy conservation and demand-side efficiency", "Hydro-electric power plants", "Geothermal energy",
+                "Oil and gas (upstream)", "Solar energy for centralised grids", "Construction policy and administrative management",
+                "Information and communication technology (ICT)", "Telecommunications", "Communications policy, planning and administration",
+                "Urban development", "Urban land policy and management", "Rural development", "Rural land policy and management", "Transport policy and administrative management", "Transport & Storage"
+            ],
+            "Ambiental": [
+                "Environmental policy and administrative management", "Environmental research", "Biodiversity", "Biosphere protection", "Flood prevention/control",
+                "Disaster Risk Reduction", "Disaster prevention and preparedness", "Multi-hazard response preparedness",
+                "Water resources conservation (including data collection)", "River basins development", "Site preservation"
+            ],
+            "Gobernanza/Público": [
+                "Public sector policy and administrative management", "Budget planning", "General budget support-related aid",
+                "Macroeconomic policy", "Debt and aid management", "Other general public services", "Other central transfers to institutions",
+                "National monitoring and evaluation", "Justice, law and order policy, planning and administration", "Civilian peace-building, conflict prevention and resolution",
+                "Security system management and reform", "Immigration", "Human rights", "Democratic participation and civil society",
+                "Anti-corruption organisations and institutions", "Ending violence against women and girls", "Women's rights organisations and movements, and government institutions",
+                "Foreign affairs", "Tax collection", "Tax policy and administration support", "Local government administration", "Local government finance",
+                "Privatisation"
+            ],
+            "Multisectorial/Otros": [
+                "Other multisector", "Sectors not specified", "Multisector aid for basic social services", "Immediate post-emergency reconstruction and rehabilitation",
+                "Material relief assistance and services", "Relief co-ordination and support services"
+            ]
+        }
+
+        _ADDITIONS = [
+            ("Gobernanza/Público", "Government & Civil Society-general"),
+            ("Gobernanza/Público", "Water sector policy and administrative management"),
+            ("Infraestructura", "Biofuel-fired power plants"),
+            ("Infraestructura", "Communications"),
+            ("Infraestructura", "Education and training in water supply and sanitation"),
+            ("Infraestructura", "Electrical transmission/ distribution"),
+            ("Infraestructura", "Employment creation"),
+            ("Infraestructura", "Energy generation, non-renewable sources, unspecified"),
+            ("Infraestructura", "Information services"),
+            ("Infraestructura", "Power generation/non-renewable sources"),
+            ("Infraestructura", "Power generation/renewable sources"),
+            ("Infraestructura", "Public Procurement"),
+            ("Infraestructura", "Public finance management (PFM)"),
+            ("Infraestructura", "Road transport"),
+            ("Infraestructura", "Trade facilitation"),
+            ("Infraestructura", "Trade policy and administrative management"),
+            ("Infraestructura", "Urban development and management"),
+            ("Multisectorial/Otros", "Decentralisation and support to subnational government"),
+            ("Multisectorial/Otros", "Education, Level Unspecified"),
+            ("Multisectorial/Otros", "Multisector aid"),
+            ("Multisectorial/Otros", "Other Social Infrastructure & Services"),
+            ("Multisectorial/Otros", "Plant and post-harvest protection and pest control"),
+            ("Productivo", "Agriculture"),
+            ("Productivo", "Domestic revenue mobilisation"),
+            ("Productivo", "Energy policy and administrative management"),
+            ("Productivo", "Fishery research"),
+            ("Productivo", "Forestry research"),
+            ("Productivo", "Forestry services"),
+            ("Productivo", "Industry"),
+            ("Productivo", "Legal and judicial development"),
+            ("Productivo", "Livestock/veterinary services"),
+            ("Productivo", "Mineral/mining policy and administrative management"),
+            ("Social", "Advanced technical and managerial training"),
+            ("Productivo", "Coal"),
+            ("Social", "Communications policy and administrative management"),
+            ("Social", "Food crop production"),
+            ("Social", "Health, General"),
+            ("Social", "Infectious disease control"),
+            ("Productivo", "Mineral prospection and exploration"),
+            ("Social", "Population policy and administrative management"),
+            ("Social", "Primary education"),
+            ("Social", "Social mitigation of HIV/AIDS"),
+            ("Social", "Statistical capacity building"),
+        ]
+
+        for macro, sector in _ADDITIONS:
+            macrosectores_dict.setdefault(macro, []).append(sector)
+
+        sector_to_macro = {
+            sector: macro
+            for macro, sectors in macrosectores_dict.items()
+            for sector in sectors
+        }
+
+        df['macro_sector'] = df['sector'].map(sector_to_macro).fillna('Otros')
+
         color_map = {
-            'Agricultural development': '#003049',
-            'Education policy and administrative management': '#034078',
-            'Electric power transmission and distribution': '#2176ff',
-            'Energy generation, renewable sources - multiple technologies': '#38b000',
-            'Environmental policy and administrative management': '#4B4E6D',
-            'Formal sector financial intermediaries': '#c1121f',
-            'General infrastructure': '#246a73',
-            'Housing policy and administrative management': '#b7bdc1',
-            'Medical services': '#fdf0d5',
-            'Rural development': '#5E6472',
-            'Sanitation - large systems': '#6C584C',
-            'Security system management and reform': '#3D405B',
-            'Social protection and welfare services policy, planning and administration': '#669bbc',
-            'Technological research and development': '#415A77',
-            'Tourism policy and administrative management': '#B7BDCB',
-            'Transport policy, planning and administration': '#1B263B',
-            'Urban development': '#274060',
-            'Waste management/disposal': '#2C363F',
-            'Water supply - large systems': '#264653',
+            'Social': '#003049',
+            'Productivo': '#034078',
+            'Infraestructura': '#2176ff',
+            'Ambiental': '#38b000',
+            'Gobernanza/Público': '#c1121f',
+            'Multisectorial/Otros': '#669bbc',
             'Otros': '#b7bdc1',
         }
-        grouped_sector = df.groupby(['año', 'RGF_clasificacion', 'sector'])['valor_usd'].sum().reset_index()
+
+        grouped_sector = df.groupby(['año', 'RGF_clasificacion', 'macro_sector'])['valor_usd'].sum().reset_index()
         grouped_sector['valor_usd_millones'] = grouped_sector['valor_usd'] / 1_000_000
         for clasif in ['Interno', 'Externo']:
             df_cl = grouped_sector[grouped_sector['RGF_clasificacion'] == clasif].copy()
@@ -215,10 +316,10 @@ elif page == 'Interno Vs Externo':
                 df_cl,
                 x='año',
                 y='valor_usd_millones',
-                color='sector',
+                color='macro_sector',
                 color_discrete_map=color_map,
-                labels={'año': 'Año', 'valor_usd_millones': 'Valor USD (millones)', 'sector': 'Sector'},
-                title=f'Aprobaciones por año y sector - {clasif}',
+                labels={'año': 'Año', 'valor_usd_millones': 'Valor USD (millones)', 'macro_sector': 'Macro sector'},
+                title=f'Aprobaciones por año y macro sector - {clasif}',
                 height=350
             )
             fig_abs.update_layout(title_x=0.5, barmode='stack')
@@ -233,10 +334,10 @@ elif page == 'Interno Vs Externo':
                 df_cl,
                 x='año',
                 y='porcentaje',
-                color='sector',
+                color='macro_sector',
                 color_discrete_map=color_map,
-                labels={'año': 'Año', 'porcentaje': 'Porcentaje (%)', 'sector': 'Sector'},
-                title=f'% por año y sector - {clasif}',
+                labels={'año': 'Año', 'porcentaje': 'Porcentaje (%)', 'macro_sector': 'Macro sector'},
+                title=f'% por año y macro sector - {clasif}',
                 height=300
             )
             fig_pct.update_layout(title_x=0.5, barmode='stack')


### PR DESCRIPTION
## Summary
- Map detailed sector labels to macrosector groups
- Show Interno vs Externo charts by macrosector when viewing sectors

## Testing
- `python -m py_compile appSadipem.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2d13e9f64833081456fd2330cb85d